### PR TITLE
fix: add optional chaining operator to the activeSubsidyStep order

### DIFF
--- a/app/controllers/subsidy/applications/edit.js
+++ b/app/controllers/subsidy/applications/edit.js
@@ -109,7 +109,7 @@ export default class SubsidyApplicationsEditController extends Controller {
     // Check if the current step has been submitted
     const activeSubsidyStep = await this.consumption
       .activeSubsidyApplicationFlowStep;
-    const activeSubsidyStepOrder = activeSubsidyStep.order;
+    const activeSubsidyStepOrder = activeSubsidyStep?.order;
     const currentStepOrder = currentStep.order;
 
     if (


### PR DESCRIPTION
## Description

Subsidies that are submitted won't have an activeStep anymore so need an optional check before accessing the order.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other
