### PR TITLE
Grab org/bestuurseenheid name from form instead of logged in user

### DIFF
--- a/app/controllers/subsidy/applications/edit.js
+++ b/app/controllers/subsidy/applications/edit.js
@@ -28,8 +28,12 @@ export default class SubsidyApplicationsEditController extends Controller {
     return this.model.consumption;
   }
 
+  get participations() {
+    return this.model.consumption.participations;
+  }
+
   get organization() {
-    return this.model.organization;
+    return this.participations.firstObject.participatingOrganization;
   }
 
   get canDelete() {

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -48,8 +48,7 @@ export default class SubsidyApplicationsEditRoute extends Route {
     );
 
     return {
-      consumption,
-      organization: this.currentSession.group,
+      consumption
     };
   }
 


### PR DESCRIPTION
## ID

DGS-437

## Description

Get org name from actual form data instead of current logged in user group. This is important for fusiebesturen.

## Type of change

- [ ] Bug fix
- [] New feature
- [ ] Breaking change
- [x] Other
