### PR TITLE
banner + disable subsidy creation for old fusie accounts

### DIFF
--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -11,11 +11,13 @@ import {
   NEW_STATUS,
   CONCEPT_STATUS,
 } from '../../../../../models/submission-document-status';
+import isOldFusieAccount from 'frontend-subsidiepunt/helpers/is-old-fusie-account';
 
 export default class SubsidyApplicationsEditStepEditController extends Controller {
   // To mimic user testing as much as possible
   // we introduce testMode queryparam, which skips some of the (blocking) frontend business logic.
   queryParams = ['testMode'];
+  @service session;
 
   @service currentSession;
   @service store;
@@ -79,6 +81,16 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
       this.consumption.belongsTo('activeSubsidyApplicationFlowStep').value()
         .order
     );
+  }
+
+  // for old fusie accounts; they can only submit e-inclusie subsidies
+  get oldFusieAccountsCheck() {
+    return isOldFusieAccount(
+      this.session.data.authenticated.relationships.group.data.id
+    )
+      ? this.consumption.subsidyMeasureOffer.get('id') ===
+          '0b5cae58-97fb-4982-9fb7-4cf660f003df'
+      : true;
   }
 
   get canSubmit() {

--- a/app/controllers/subsidy/applications/index.js
+++ b/app/controllers/subsidy/applications/index.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
 import { SENT_STATUS } from '../../../models/submission-document-status';
+import { inject as service } from '@ember/service';
 
 export default class SubsidyApplicationsIndexController extends Controller {
+  @service() session;
   page = 0;
   size = 20;
   sort = '-modified';

--- a/app/helpers/is-old-fusie-account.js
+++ b/app/helpers/is-old-fusie-account.js
@@ -1,0 +1,71 @@
+export default function isOldFusieAccount(groupId) {
+  const group = `http://data.lblod.info/id/bestuurseenheden/` + groupId;
+
+  const oldFusieAccountIds = [
+    // Beveren-Kruibeke-Zwijndrecht
+    'http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7', // Beveren - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/72bc672ceb6894d8dd31dc2dff2faad2fd93f4b9f5347d556d092516eaa30aa3', // Beveren - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539', // Kruibeke - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/d3c76fd84794dad5e12c9eed6d6332dc5e5c99daf0e4ddd7ceebf13d5d6c0ccd', // Kruibeke - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d', // Zwijndrecht - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/bbc23313f4c8585a0c51f15f920d77123356535cd1cad9af38f5707892c7088d', // Zwijndrecht - ocmw
+
+    // Bilzen-Hoeselt
+    'http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156', // Hoeselt - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/785e8d5516378c7382ad0e7e356d2301496d810c6cd46d72ccebb455d3ac525e', // Hoeselt - ocmw
+
+    // Tongeren-Borgloon
+    'http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f', // Borgloon - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/3834647b5e95ea20f5ffe5a12a09fbd3d7fdf0d187fab385cb7b841422176ad6', // Borgloon - ocmw
+
+    // Nazareth-De Pinte
+    'http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db', // Nazareth - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/0a2d980559eb9f3e0820386541274a72692f495204cd6d951ea1907ecc65829b', // Nazareth - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee', // De Pinte - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/144c75e403c5084af57f5c0c86252b8759b56baf9694326abbcb5ea40ab69f1a', // De Pinte - ocmw
+
+    // Pajottegem
+    'http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d', // Galmaarden - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/ba8a253d98ea7d2ab1afc43e5e2cd145a12ccd86b68e71d023e3c13a83d7498f', // Galmaarden - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2', // Gooik - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/76c45d60f05bf8afc8c71859342b69cac6a57ee2b320b900a60afd6ba9b8eb9d', // Gooik - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0', // Herne - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/5d21ccef2f5aa3ccbf3a74c6f25ebe9f0b1ef5a97b87f3d79c86ae9d6d857df8', // Herne - ocmw
+
+    // Tessenderlo-Ham
+    'http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9', // Tessenderlo - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682', // Tessenderlo - ocmw
+
+    // Hasselt
+    'http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb', // Kortessem - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9', // Kortessem - ocmw
+
+    // Lochistri
+    'http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd', // Wachtebeke - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/7c6b38fa6fc65879cb674a654617de171adfcfacba086fb918da3749dbaa43b5', // Wachtebeke - ocmw
+
+    // Lokeren
+    'http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2', // Moerbeke - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/f2a9a2392d5e4c0f992a84a0871d048a7b91b14681e9980a63aa6ba4b1f7eb8c', // Moerbeke - ocmw
+
+    // Merelbeke-Melle
+    'http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945', // Melle - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e', // Melle - ocmw
+    'http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f', // Merelbeke - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/f56f068943a99059f5bfc3b905fe8848a25a47cfa30fb3ed3d294b47815b2255', // Merelbeke - ocmw
+
+    // Tielt
+    'http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515', // Meulebeke - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/3f57a17fbcdfc13def910c54948bec11d71d3f75946b0336fffc0587bf18d783', // Meulebeke - ocmw
+
+    // Wingene
+    'http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52', // Ruiselede - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/60daf27c2cf12dd123447aa300dd7320890391dbd8dd6b4dd7ec02258f8281b3', // Ruiselede - ocmw
+
+    // Antwerpen
+    'http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117', // Borsbeek - gemeente
+    'http://data.lblod.info/id/bestuurseenheden/7125fcbfb7a08f8c01efbed115cea602db249c04afe9b5a2cc298cc7949cd040', // Borsbeek - ocmw
+  ];
+
+  return oldFusieAccountIds.includes(group);
+}

--- a/app/routes/subsidy/applications/available-subsidies.js
+++ b/app/routes/subsidy/applications/available-subsidies.js
@@ -2,12 +2,15 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
+import isOldFusieAccount from 'frontend-subsidiepunt/helpers/is-old-fusie-account';
 
 export default class SubsidyApplicationsAvailableSubsidiesRoute extends Route.extend(
   DataTableRouteMixin
 ) {
+  @service session;
   @service currentSession;
   @service store;
+  @service router;
 
   modelName = 'subsidy-measure-offer-series';
 
@@ -21,6 +24,16 @@ export default class SubsidyApplicationsAvailableSubsidiesRoute extends Route.ex
     size: { refreshModel: true },
     sort: { refreshModel: true },
   };
+
+  beforeModel() {
+    if (
+      isOldFusieAccount(
+        this.session.data.authenticated.relationships.group.data.id
+      )
+    ) {
+      this.router.replaceWith('subsidy.applications');
+    }
+  }
 
   mergeQueryOptions(params) {
     const query = {

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -48,7 +48,7 @@ export default class SubsidyApplicationsEditRoute extends Route {
     );
 
     return {
-      consumption
+      consumption,
     };
   }
 

--- a/app/routes/subsidy/applications/index.js
+++ b/app/routes/subsidy/applications/index.js
@@ -2,7 +2,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
-import { ROLES } from 'frontend-subsidiepunt/models/participation';
 
 export default class SubsidyApplicationsIndexRoute extends Route.extend(
   DataTableRouteMixin
@@ -22,7 +21,7 @@ export default class SubsidyApplicationsIndexRoute extends Route.extend(
         'active-subsidy-application-flow-step.subsidy-procedural-step.period',
         'participations',
         'last-modifier',
-      ].join(',')
+      ].join(','),
     };
   }
 }

--- a/app/routes/subsidy/applications/index.js
+++ b/app/routes/subsidy/applications/index.js
@@ -6,6 +6,7 @@ import DataTableRouteMixin from 'ember-data-table/mixins/route';
 export default class SubsidyApplicationsIndexRoute extends Route.extend(
   DataTableRouteMixin
 ) {
+  @service session;
   @service currentSession;
   @service store;
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,21 +2,12 @@
 
 <AuApp>
   <GlobalSystemNotification />
-  <AuMainHeader
-    @brandLink={{unless
-      this.session.isAuthenticated
-      "https://www.vlaanderen.be/nl"
-    }}
-    @homeRoute="index"
-    @appTitle={{this.appTitle}}
-  >
+  <AuMainHeader @brandLink={{unless this.session.isAuthenticated "https://www.vlaanderen.be/nl" }} @homeRoute="index"
+    @appTitle={{this.appTitle}}>
     <ul class="au-c-list-horizontal">
       <li class="au-c-list-horizontal__item au-u-hide-on-print">
-        <AuLinkExternal
-          href="https://abb-vlaanderen.gitbook.io/handleiding-loket/veelgestelde-vragen"
-          @skin="secondary"
-          @icon="question-circle"
-        >
+        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/handleiding-loket/veelgestelde-vragen" @skin="secondary"
+          @icon="question-circle">
           Help
         </AuLinkExternal>
       </li>
@@ -25,10 +16,7 @@
         {{! template-lint-disable require-context-role }}
         <AuDropdown
           @title="{{this.currentSession.user.voornaam}} {{this.currentSession.user.achternaam}} - {{this.currentSession.groupClassification.label}} {{this.currentSession.group.naam}}"
-          @buttonLabel="Account settings"
-          @alignment="right"
-          class="logged-in-user"
-        >
+          @buttonLabel="Account settings" @alignment="right" class="logged-in-user">
           <AuLink @route="auth.switch" @icon="switch" role="menuitem">
             Wissel van organisatie
           </AuLink>
@@ -38,7 +26,7 @@
           </AuLink>
         </AuDropdown>
         {{! template-lint-enable require-context-role }}
-      {{else}}
+        {{else}}
         <LoginButton @isCompact={{true}} />
         {{/if}}
       </li>
@@ -46,35 +34,47 @@
   </AuMainHeader>
 
   {{#if this.session.isAuthenticated}}
-    <AuMainContainer as |main|>
-      <main.content>
-        <AuBodyContainer>
-          {{#unless this.isIndexOrLoading}}
-            <AuToolbar class="au-u-hide-on-print" @size="medium" @skin="tint" @border="bottom" as |Group|>
-              <Group>
-                <nav aria-label="Breadcrumb">
-                  <ol
-                    class="au-c-list-horizontal au-c-list-horizontal--small"
-                  >
-                    <li class="au-c-list-horizontal__item">
-                      <AuLink @route="subsidy.applications" @icon="arrow-left">
-                        Terug naar overzicht
-                      </AuLink>
-                    </li>
-                    <BreadCrumb />
-                  </ol>
-                </nav>
-              </Group>
-            </AuToolbar>
-          {{/unless}}
-          <AuBodyContainer id="content">
-            {{outlet}}
-          </AuBodyContainer>
+  <AuMainContainer as |main|>
+    <main.content>
+      <AuBodyContainer>
+        {{#if (is-old-fusie-account this.session.data.authenticated.relationships.group.data.id)}}
+        <AuAlert @size='tiny' @skin='warning' class='au-u-margin-small'>
+          <div>
+            <p>
+              Let op: Dit account is alleen-lezen vanaf 1 januari 2025. Aanvragen van nieuwe subsidies (met
+              uitzondering van <span class='au-u-medium'>e-inclusie</span>) is hier niet langer toegestaan. Voor meer
+              informatie of het indienen van
+              een nieuwe aanvraag, gebruik het nieuwe account. Toegang tot dit account blijft mogelijk tot 1 juli
+              2025.
+            </p>
+          </div>
+        </AuAlert>
+        {{/if}}
+
+        {{#unless this.isIndexOrLoading}}
+        <AuToolbar class="au-u-hide-on-print" @size="medium" @skin="tint" @border="bottom" as |Group|>
+          <Group>
+            <nav aria-label="Breadcrumb">
+              <ol class="au-c-list-horizontal au-c-list-horizontal--small">
+                <li class="au-c-list-horizontal__item">
+                  <AuLink @route="subsidy.applications" @icon="arrow-left">
+                    Terug naar overzicht
+                  </AuLink>
+                </li>
+                <BreadCrumb />
+              </ol>
+            </nav>
+          </Group>
+        </AuToolbar>
+        {{/unless}}
+        <AuBodyContainer id="content">
+          {{outlet}}
         </AuBodyContainer>
-      </main.content>
-    </AuMainContainer>
+      </AuBodyContainer>
+    </main.content>
+  </AuMainContainer>
   {{else}}
-    {{outlet}}
+  {{outlet}}
   {{/if}}
 </AuApp>
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -38,14 +38,21 @@
     <main.content>
       <AuBodyContainer>
         {{#if (is-old-fusie-account this.session.data.authenticated.relationships.group.data.id)}}
-        <AuAlert @size='tiny' @skin='warning' class='au-u-margin-small'>
+        <AuAlert
+          @title="Dit account is uitsluitend raadpleegbaar. (uitzondering e-inclusie)"
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+          class='au-u-margin-small au-u-max-width-medium'
+          @closable={{true}}
+        >
           <div>
             <p>
-              Let op: Dit account is alleen-lezen vanaf 1 januari 2025. Aanvragen van nieuwe subsidies (met
-              uitzondering van <span class='au-u-medium'>e-inclusie</span>) is hier niet langer toegestaan. Voor meer
-              informatie of het indienen van
-              een nieuwe aanvraag, gebruik het nieuwe account. Toegang tot dit account blijft mogelijk tot 1 juli
-              2025.
+              Het indienen van nieuwe subsidiedossiers is niet langer mogelijk (met uitzondering van aanvragen voor <span class='au-u-medium'>e-inclusie</span>).
+
+Voor meer informatie of om een nieuwe aanvraag in te dienen, dient u gebruik te maken van het nieuwe account dat beschikbaar is gesteld na de fusie van de gemeenten.
+
+Toegang tot dit account blijft behouden tot 1 juli 2025, waarna het volledig afgesloten zal worden.
             </p>
           </div>
         </AuAlert>

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -8,7 +8,7 @@
         @icon="redo"
         @closable={{false}}
       >
-        <p> Dit kan komen door een verlopen indieningsdatum, een nieuwere versie, of een andere reden. U hoeft zich geen zorgen te maken: deze stap is niet verwerkt. 
+        <p> Dit kan komen door een verlopen indieningsdatum, een nieuwere versie, of een andere reden. U hoeft zich geen zorgen te maken: deze stap is niet verwerkt.
           <br>Denkt u dat dit onterecht is en wilt u de stap alsnog indienen? Neem dan contact op via <a href="mailto:LoketLokaalBestuur@vlaanderen.be"
                       class="au-c-link">LoketLokaalBestuur@vlaanderen.be</a>.</p>
       </AuAlert>
@@ -17,7 +17,7 @@
   <div
     class="au-o-box {{if (or this.saveConcept.isRunning this.submit.isRunning) 'au-c-form--disabled'}}"
   >
-  
+
     <RdfForm
       @groupClass="au-o-grid__item"
       @form={{this.form}}
@@ -67,34 +67,36 @@
     <Group class="au-u-margin-top-small au-u-margin-bottom-small">
       {{! DEFAULT CRUD CASE }}
       {{#if this.canSubmit}}
-        <AuButton
-          @disabled={{if
-            (or
-              this.saveConcept.isRunning
-              this.submit.isRunning
-              this.delete.isRunning
-            )
-            "true"
-          }}
-          @loading={{if this.submit.isRunning "true"}}
-          {{on "click" (perform this.submit)}}
-        >Verstuur naar de Vlaamse overheid
-        </AuButton>
-        <AuButton
-          @disabled={{if
-            (or
-              this.saveConcept.isRunning
-              this.submit.isRunning
-              this.delete.isRunning
-            )
-            "true"
-          }}
-          @loading={{if this.saveConcept.isRunning "true"}}
-          @skin={{"secondary"}}
-          {{on "click" (perform this.saveConcept)}}
-        >
-          Bewaar als concept
-        </AuButton>
+        {{#if this.oldFusieAccountsCheck}}
+          <AuButton
+            @disabled={{if
+              (or
+                this.saveConcept.isRunning
+                this.submit.isRunning
+                this.delete.isRunning
+              )
+              "true"
+            }}
+            @loading={{if this.submit.isRunning "true"}}
+            {{on "click" (perform this.submit)}}
+          >Verstuur naar de Vlaamse overheid
+          </AuButton>
+          <AuButton
+            @disabled={{if
+              (or
+                this.saveConcept.isRunning
+                this.submit.isRunning
+                this.delete.isRunning
+              )
+              "true"
+            }}
+            @loading={{if this.saveConcept.isRunning "true"}}
+            @skin={{"secondary"}}
+            {{on "click" (perform this.saveConcept)}}
+          >
+            Bewaar als concept
+          </AuButton>
+        {{/if}}
       {{else}}
         {{! SENDING NOT POSSIBLE }}
         {{#if this.submitted}}

--- a/app/templates/subsidy/applications/index-loading.hbs
+++ b/app/templates/subsidy/applications/index-loading.hbs
@@ -7,13 +7,6 @@
       <p>Lopende subsidieaanvragen voor uw organisatie.</p>
     </div>
   </Group>
-  <Group>
-    <div class="au-u-text-right">
-      <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">
-        Vraag nieuwe subsidie aan
-      </LinkTo>
-    </div>
-  </Group>
 </AuToolbar>
 <div class="au-c-data-table">
   <div class="au-c-data-table__wrapper">

--- a/app/templates/subsidy/applications/index.hbs
+++ b/app/templates/subsidy/applications/index.hbs
@@ -9,9 +9,11 @@
   </Group>
   <Group>
     <div class="au-u-text-right">
+      {{#unless (is-old-fusie-account this.session.data.authenticated.relationships.group.data.id)}}
       <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">Vraag nieuwe subsidie
         aan
       </LinkTo>
+      {{/unless}}
     </div>
   </Group>
 </AuToolbar>


### PR DESCRIPTION
## ID

DGS-430

## Description

Show a banner and disable the creating of subsidies, and submiting of subsidies other than e-inlcusie for old fusie accounts.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Other

## How to test

Log in as different users from the fusie and as non-fusie users. Verify that the banner appears, 'aanvraag nieuwe subsidie' button disappears, and the available-subsidies route gets redirected `http://localhost:4200/subsidy/applications/available-subsidies`.

The old fusie users should also not be able to submit anymore of the subsidies, except for e-inclusie.
