### PR TITLE
Add error substates for edit & new aanvraag routes

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -34,6 +34,8 @@ Router.map(function () {
           this.route('edit', { path: '/forms/:form_id' });
         });
       });
+      this.route('edit-error');
+      this.route('new-error');
     });
   });
 

--- a/app/routes/subsidy/applications/edit-error.js
+++ b/app/routes/subsidy/applications/edit-error.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class SubsidyApplicationsEditErrorRoute extends Route {}

--- a/app/routes/subsidy/applications/new-error.js
+++ b/app/routes/subsidy/applications/new-error.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class SubsidyApplicationsNewErrorRoute extends Route {}

--- a/app/templates/subsidy/applications/edit-error.hbs
+++ b/app/templates/subsidy/applications/edit-error.hbs
@@ -1,0 +1,9 @@
+<div class="au-o-box">
+  <AuHeading @skin="4">Oeps! Dit is een beetje gênant ...</AuHeading>
+  <AuHelpText class="au-u-margin-left-none">
+    Het lijkt er op dat er iets is foutgelopen bij het opladen van dit dossier.
+    <br>Indien dit probleem zich blijft voordoen kunt u contact op nemen met
+    <a href="mailto:LoketLokaalBestuur@vlaanderen.be"
+       class="au-c-link">LoketLokaalBestuur@vlaanderen.be</a>.
+  </AuHelpText>
+</div>

--- a/app/templates/subsidy/applications/new-error.hbs
+++ b/app/templates/subsidy/applications/new-error.hbs
@@ -1,0 +1,9 @@
+<div class="au-o-box">
+  <AuHeading @skin="4">Oeps! Dit is een beetje gênant ...</AuHeading>
+  <AuHelpText class="au-u-margin-left-none">
+    Het lijkt er op dat er iets is foutgelopen bij het aanmaken van dit dossier.
+    <br>Indien dit probleem zich blijft voordoen kunt u contact op nemen met
+    <a href="mailto:LoketLokaalBestuur@vlaanderen.be"
+       class="au-c-link">LoketLokaalBestuur@vlaanderen.be</a>.
+  </AuHelpText>
+</div>

--- a/tests/unit/routes/subsidy/applications/edit-error-test.js
+++ b/tests/unit/routes/subsidy/applications/edit-error-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-subsidiepunt/tests/helpers';
+
+module('Unit | Route | subsidy/applications/edit-error', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:subsidy/applications/edit-error');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/subsidy/applications/new-error-test.js
+++ b/tests/unit/routes/subsidy/applications/new-error-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-subsidiepunt/tests/helpers';
+
+module('Unit | Route | subsidy/applications/new-error', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:subsidy/applications/new-error');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## ID

DL-3598

## Description

Instead of showing an error message, when a aanvraag fails to load, it will just keep showing the loading screen

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Other

## How to test

Start the stack, the go to a subsidy aanvraag, and edit the url (modifying the uuids often triggers and error)