### PR TITLE
fix issue where lastModifier is not saved

### DIFF
--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -282,7 +282,7 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
 
   async updateModified(model) {
     model.modified = new Date();
-    model.lastModified = this.currentSession.user;
+    model.lastModifier = this.currentSession.user;
     await model.save();
   }
 


### PR DESCRIPTION
## ID

DGS-226

## Description

While checkout out the implementation of lastModifier in subsidiepunt since we wanna do something similar in lpdc I noticed the issue 'lastModifier' vs 'lastModified' and remembered not too long ago we had a bug that this field was not updating correctly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## How to test

If you first go to subsidiepunt on QA, mock-login with 'gemeente affligem' and try changing any of the forms (with for example no 'gewijzigd door' field yet)
-> normally updating the form should  add 'Gemeente Affligem' as the last modifier, but this is not the case

After setting up this PR with the QA backend, updating the form should correctly update the field
-> 'Gemeente affligem' should now correctly be in the 'gewijzigd door' field
